### PR TITLE
Changing URI in Dockerfile_client

### DIFF
--- a/Dockerfile_client
+++ b/Dockerfile_client
@@ -1,4 +1,4 @@
-FROM personalrobotics/openrave
+FROM personalrobotics/ros-openrave
 MAINTAINER Michael Koval <mkoval@cs.cmu.edu>
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Running `./run_wstool.sh` was failing with:

```
Step 1 : FROM personalrobotics/openrave
Pulling repository docker.io/personalrobotics/openrave
Error: image personalrobotics/openrave:latest not found
```

@ClintLiddick told me to fix Dockerfile_client file and it seems to work. :) 
