### PR TITLE
Add -e flag to build and test scripts.

### DIFF
--- a/internal-build.sh
+++ b/internal-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 SUDO='sudo -n'
 CATKIN_BUILD='catkin build --no-status -p 1 -i'
 

--- a/internal-test.sh
+++ b/internal-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 CATKIN_BUILD='catkin build --no-status -p 1 -i'
 BUILD_PATH='build'
 OUTPUT_PATH='test_results'


### PR DESCRIPTION
Resolves https://github.com/personalrobotics/aikido/issues/269.

The `build` and `test` scripts are the only ones without the `-e` flag enabled, which seemed strange to me.