### PR TITLE
Revert "Add -e flag to build and test scripts."

### DIFF
--- a/internal-build.sh
+++ b/internal-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 SUDO='sudo -n'
 CATKIN_BUILD='catkin build --no-status -p 1 -i'
 

--- a/internal-test.sh
+++ b/internal-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 CATKIN_BUILD='catkin build --no-status -p 1 -i'
 BUILD_PATH='build'
 OUTPUT_PATH='test_results'


### PR DESCRIPTION
Reverts personalrobotics/pr-cleanroom#7

After reading the scripts more carefully, I noticed that the `-e` flag was already enabled for the `build` script in the `set -xe` line. The `test` script doesn't have the `-e` flag because (I guess) we want to compile the tests and then run whichever tests have been successfully built?