### PR TITLE
Add option to internal-distro.py to set manifest file

### DIFF
--- a/internal-distro.py
+++ b/internal-distro.py
@@ -76,6 +76,7 @@ def main():
     parser.add_argument('distribution_file', type=str)
     parser.add_argument('--package', type=str, action='append', dest='target_packages', default=[])
     parser.add_argument('--repository', type=str, action='append', dest='target_repositories', default=[])
+    parser.add_argument('--manifest_name', type=str, default='package.xml')
     args = parser.parse_args()
 
     if not os.path.exists(args.workspace):
@@ -166,7 +167,7 @@ def main():
             # Search for packages in the repository.
             repository_package_map = dict()
             rospkg.list_by_path(
-                manifest_name='package.xml',
+                manifest_name=args.manifest_name,
                 path=repository.location,
                 cache=repository_package_map)
 
@@ -202,7 +203,7 @@ def main():
             installed_packages.update(repository_package_map.iterkeys())
 
         # Crawl dependencies.
-        package_xml_path = os.path.join(package.location, 'package.xml')
+        package_xml_path = os.path.join(package.location, args.manifest_name)
         package_manifest = parse_package(package_xml_path)
 
         all_depends = set()

--- a/internal-distro.py
+++ b/internal-distro.py
@@ -76,6 +76,7 @@ def main():
     parser.add_argument('distribution_file', type=str)
     parser.add_argument('--package', type=str, action='append', dest='target_packages', default=[])
     parser.add_argument('--repository', type=str, action='append', dest='target_repositories', default=[])
+    parser.add_argument('--manifest_file', type=str, default='package.xml')
     args = parser.parse_args()
 
     if not os.path.exists(args.workspace):
@@ -202,7 +203,7 @@ def main():
             installed_packages.update(repository_package_map.iterkeys())
 
         # Crawl dependencies.
-        package_xml_path = os.path.join(package.location, 'package-full.xml')
+        package_xml_path = os.path.join(package.location, args.manifest_file)
         if not os.path.isfile(package_xml_path):
             package_xml_path = os.path.join(package.location, 'package.xml')
         package_manifest = parse_package(package_xml_path)

--- a/internal-distro.py
+++ b/internal-distro.py
@@ -76,7 +76,6 @@ def main():
     parser.add_argument('distribution_file', type=str)
     parser.add_argument('--package', type=str, action='append', dest='target_packages', default=[])
     parser.add_argument('--repository', type=str, action='append', dest='target_repositories', default=[])
-    parser.add_argument('--manifest_name', type=str, default='package.xml')
     args = parser.parse_args()
 
     if not os.path.exists(args.workspace):
@@ -167,7 +166,7 @@ def main():
             # Search for packages in the repository.
             repository_package_map = dict()
             rospkg.list_by_path(
-                manifest_name=args.manifest_name,
+                manifest_name='package.xml',
                 path=repository.location,
                 cache=repository_package_map)
 
@@ -203,7 +202,9 @@ def main():
             installed_packages.update(repository_package_map.iterkeys())
 
         # Crawl dependencies.
-        package_xml_path = os.path.join(package.location, args.manifest_name)
+        package_xml_path = os.path.join(package.location, 'package-full.xml')
+        if not os.path.isfile(package_xml_path):
+            package_xml_path = os.path.join(package.location, 'package.xml')
         package_manifest = parse_package(package_xml_path)
 
         all_depends = set()


### PR DESCRIPTION
Since there is no way to specify optional dependencies in `package.xml`, AIKIDO [changed](https://github.com/personalrobotics/aikido/pull/364) its `package.xml` to include only required dependencies (for simulation only). However, the change [makes CI tests of libherb](https://travis-ci.com/personalrobotics/libherb/jobs/119094922) fail because [libherb requires full version of AIKIDO](https://travis-ci.com/personalrobotics/libherb/jobs/119094922#L3383).

AIKIDO, to resolve the issue, additionally provides `package-full.xml` that includes all the dependencies including the optionals. This PR adds an option to `internal-distro.py` to set which package manifest file to use. If the option is not specified or the file doesn't exist, it will fall back to using `package.xml`.

Related issues:
* https://github.com/personalrobotics/pr-rosinstalls/pull/36
* https://github.com/personalrobotics/aikido/pull/364