### PR TITLE
Only catkin build if packages are provided.

### DIFF
--- a/internal-build.sh
+++ b/internal-build.sh
@@ -33,4 +33,6 @@ ${SUDO} apt-get update
 rosdep update
 rosdep install -y --ignore-src --rosdistro=${ROS_DISTRO} --from-paths src
 
-${CATKIN_BUILD} -p1 -- "$@"
+if [ "$#" -gt 0 ]; then
+  ${CATKIN_BUILD} -p1 -- "$@"
+fi


### PR DESCRIPTION
This might be useful if we want to configure the Catkin workspace but don't need to build anything, e.g. for documentation builds.