### PR TITLE
Update ROS keyserver URL

### DIFF
--- a/internal-setup.sh
+++ b/internal-setup.sh
@@ -18,7 +18,7 @@ set -x
 # Add the ROS apt repository.
 if [ ! -f /etc/apt/sources.list.d/ros-latest.list ]; then
   ${SUDO} sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-  ${SUDO} apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+  ${SUDO} apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 fi
 
 # Add necessary apt repositories.


### PR DESCRIPTION
The ROS keyserver URL seems to be outdated according to the [ROS installation instruction](http://wiki.ros.org/melodic/Installation/Ubuntu), and this is probably one of the causes of the AIKIDO build failures.

This might be related to #21 as well.